### PR TITLE
Fix session expiration duration format

### DIFF
--- a/app/src/Request/Auth/LoginRequest.php
+++ b/app/src/Request/Auth/LoginRequest.php
@@ -35,8 +35,12 @@ class LoginRequest extends Filter
         'code'     => 'strval',
         'remember' => 'boolval',
     ];
-    private const DEFAULT_DURATION  = 'PT24H';
-    private const REMEMBER_DURATION = 'PT30D';
+
+    /**
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
+     */
+    private const DEFAULT_DURATION  = 'P1D';
+    private const REMEMBER_DURATION = 'P1M';
 
     /**
      * @return string


### PR DESCRIPTION
`DateInterval::__construct(): Unknown or bad format (PT30D)in /home/user/work/project/app/src/Request/Auth/LoginRequest.php:49`

```
PHP 7.4.16 (cli) (built: Mar  5 2021 07:54:38) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.16, Copyright (c), by Zend Technologies
```