### PR TITLE
Fix Docker build error on iconv

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -29,7 +29,7 @@ RUN apk update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install \
-        mbstring opcache iconv pdo \
+        mbstring opcache pdo \
         gd dom exif intl json soap tokenizer xsl zip pcntl bcmath sockets \
         && pecl install -o -f redis imagick &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis imagick \
         && docker-php-source delete \


### PR DESCRIPTION
Context
--------
When building docker PHP image, we got an error on iconv
```bash
#6 58.88 /bin/sh /usr/src/php/ext/iconv/libtool --mode=compile cc -I"/usr/include" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -I. -I/usr/src/php/ext/iconv -DPHP_ATOM_INC -I/usr/src/php/ext/iconv/include -I/usr/src/php/ext/iconv/main -I/usr/src/php/ext/iconv -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib  -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CONFIG_H  -I/usr/include -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64   -c /usr/src/php/ext/iconv/iconv.c -o iconv.lo
#6 58.93 mkdir .libs
#6 58.93  cc -I/usr/include -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -I. -I/usr/src/php/ext/iconv -DPHP_ATOM_INC -I/usr/src/php/ext/iconv/include -I/usr/src/php/ext/iconv/main -I/usr/src/php/ext/iconv -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CONFIG_H -I/usr/include -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -c /usr/src/php/ext/iconv/iconv.c  -fPIC -DPIC -o .libs/iconv.o
#6 58.94 In file included from /usr/local/include/php/Zend/zend_config.h:1,
#6 58.94                  from /usr/local/include/php/Zend/zend_portability.h:43,
#6 58.94                  from /usr/local/include/php/Zend/zend_types.h:25,
#6 58.94                  from /usr/local/include/php/Zend/zend.h:27,
#6 58.94                  from /usr/local/include/php/main/php.h:33,
#6 58.94                  from /usr/src/php/ext/iconv/iconv.c:25:
#6 58.94 /usr/local/include/php/main/../main/php_config.h:1976: warning: "ICONV_BROKEN_IGNORE" redefined
#6 58.94  1976 | #define ICONV_BROKEN_IGNORE 0
#6 58.94       |
#6 58.95 In file included from /usr/src/php/ext/iconv/iconv.c:22:
#6 58.95 /usr/src/php/ext/iconv/config.h:59: note: this is the location of the previous definition
#6 58.95    59 | #define ICONV_BROKEN_IGNORE 1
#6 58.95       |
#6 59.13 /usr/src/php/ext/iconv/iconv.c: In function 'zm_startup_miconv':
#6 59.13 /usr/src/php/ext/iconv/iconv.c:284:4: error: '_libiconv_version' undeclared (first use in this function)
#6 59.13   284 |    _libiconv_version >> 8, _libiconv_version & 0xff);
#6 59.13       |    ^~~~~~~~~~~~~~~~~
#6 59.13 /usr/src/php/ext/iconv/iconv.c:284:4: note: each undeclared identifier is reported only once for each function it appears in
#6 59.14 /usr/src/php/ext/iconv/iconv.c: In function '_php_iconv_appendl':
#6 59.14 /usr/src/php/ext/iconv/iconv.c:181:15: warning: implicit declaration of function 'libiconv'; did you mean 'iconv'? [-Wimplicit-function-declaration]
#6 59.14   181 | #define iconv libiconv
#6 59.14       |               ^~~~~~~~
#6 59.14 /usr/src/php/ext/iconv/iconv.c:453:8: note: in expansion of macro 'iconv'
#6 59.14   453 |    if (iconv(cd, (char **)&in_p, &in_left, (char **) &out_p, &out_left) == (size_t)-1) {
#6 59.14       |        ^~~~~
#6 59.18 make: *** [Makefile:192: iconv.lo] Error 1
------
executor failed running [/bin/sh -c docker-php-ext-install         mbstring opcache iconv pdo         gd dom exif intl json soap tokenizer xsl zip pcntl bcmath sockets         && pecl install -o -f redis imagick &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis imagick         && docker-php-source delete         && apk del ${BUILD_DEPENDS}]: exit code: 2
ERROR: Service 'php' failed to build : Build failed
```

I suggest to remove `iconv` from `docker-php-ext-install`